### PR TITLE
Run periodic check set VF mac admin in case of reset

### DIFF
--- a/api/v1/helper.go
+++ b/api/v1/helper.go
@@ -310,6 +310,7 @@ func (p *SriovNetworkNodePolicy) Apply(state *SriovNetworkNodeState, merge bool)
 				Name:        iface.Name,
 				LinkType:    p.Spec.LinkType,
 				EswitchMode: p.Spec.EswitchMode,
+				IsRdma:      p.Spec.IsRdma,
 			}
 			var group *VfGroup
 			if p.Spec.NumVfs > 0 {

--- a/api/v1/sriovnetworknodestate_types.go
+++ b/api/v1/sriovnetworknodestate_types.go
@@ -21,6 +21,7 @@ type Interface struct {
 	Name        string    `json:"name,omitempty"`
 	LinkType    string    `json:"linkType,omitempty"`
 	EswitchMode string    `json:"eSwitchMode,omitempty"`
+	IsRdma      bool      `json:"isRdma,omitempty"`
 	VfGroups    []VfGroup `json:"vfGroups,omitempty"`
 }
 

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
@@ -44,6 +44,8 @@ spec:
                   properties:
                     eSwitchMode:
                       type: string
+                    isRdma:
+                      type: boolean
                     linkType:
                       type: string
                     mtu:

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,7 @@ github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF0
 github.com/Masterminds/sprig v2.20.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
+github.com/Mellanox/rdmamap v1.0.0 h1:5OQX6n85GDKetHP9wBqxy/0Ce2+taRg+4nSTsNOCyKQ=
 github.com/Mellanox/rdmamap v1.0.0/go.mod h1:fN+/V9lf10ABnDCwTaXRjeeWijLt2iVLETnK+sx/LY8=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=


### PR DESCRIPTION
SR-IOV VFs may lose their admin mac due to third party interaction or maintain in the node like reload modules, which cause an issue especially for RDMA that will lose the node_guid for the VFs which cause no RDMA traffic between the VFs